### PR TITLE
traditional config parser

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,11 +25,11 @@ gulp.task('test', function() {
 gulp.task('cover', function() {
   gulp.src(allJSFiles)
     .pipe($.istanbul())
-    .on('end', function(){
+    .on('end', function() {
       gulp.src(allJSFiles)
         .pipe($.mocha())
-        .pipe($.istanbul.writeReports('coverage'))
-    })
+        .pipe($.istanbul.writeReports('coverage'));
+    });
 });
 
 gulp.task('jscs', function() {

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -1,0 +1,151 @@
+/**
+ * Parse and Build server config from traditional server config.
+ *
+ * This module exists as sample of implement config builder.
+ *
+ * There is a limitation, can not parse quoted strings perfectly.
+ * So it is not allowed to use double-quote character in topic text.
+ * This won't be fixed, for maintenance cost reason. use JSON config.
+ *
+ * NOTE: This module will be an obsolute module after v1.0
+ */
+
+// TODO: lineno for parse error
+// TODO: selectable safe parse or raise error
+
+var fs = require('fs');
+var format = require('util').format;
+var readline = require('readline');
+var _ = require('lodash');
+
+/**
+ * @private
+ */
+function parseBoolean(x) {
+  return (x === 'yes') ? true : (x === 'no') ? false : null;
+}
+
+/**
+ * @private
+ */
+function shlex_split(line) {
+  return line.match(/"([^"]+)"/);
+}
+
+/**
+ *
+ */
+function ConfigBuilder() {
+  var config = {
+    ACL: {},
+    User: {}
+  }
+
+  this.Port = function(port) {
+    config.Port = _.parseInt(port);
+  };
+  this.MaxUsers = function(maxUsers) {
+    config.MaxUsers = _.parseInt(maxUsers);
+  };
+  this.MaxChannels = function(maxUserChannels, maxAnonChannels) {
+    // XXX: Hits parseInt/map strange behavior
+    // parseInt takes two argument map given a pair of element and the index.
+    config.MaxChannels = _.map([maxUserChannels, maxAnonChannels], Number);
+  };
+  this.DefaultTopic = function(defaultTopic) {
+    config.DefaultTopic = defaultTopic;
+  };
+  this.DefaultBPM = function(defaultBpm) {
+    config.DefaultBPM = _.parseInt(defaultBpm);
+  };
+  this.DefaultBPI = function(defaultBpi) {
+    config.DefaultBPI = _.parseInt(defaultBpi);
+  };
+  this.ServerLicense = function(serverLicense) {
+    config.ServerLicense = serverLicense;
+  };
+  this.AnonymousUsers = function(anonymousUsers) {
+    config.AnonymousUsers = parseBoolean(anonymousUsers);
+  };
+  this.AnonymousUsersCanChat = function(anonymousUsersCanChat) {
+    config.AnonymousUsersCanChat = parseBoolean(anonymousUsersCanChat);
+  };
+  this.AnonymousMaskIP = function(anonymousMaskIP) {
+    config.AnonymousMaskIP = parseBoolean(anonymousMaskIP);
+  };
+  this.AllowHiddenUsers = function(allowHiddenUsers) {
+    config.AllowHiddenUsers = parseBoolean(allowHiddenUsers);
+  };
+  this.ACL = function(mask, access) {
+    config.ACL[mask] = access;
+  };
+  this.User = function(name, pass, perm) {
+    perm = (perm === undefined) ? '*' : perm;
+    config.User[name] = {pass: pass, perm: perm};
+  };
+  this.SetVotingThreshold = function(setVotingThreshold) {
+    config.SetVotingThreshold = _.parseInt(setVotingThreshold);
+  };
+  this.SetVotingVoteTimeout = function(setVotingVoteTimeout) {
+    config.SetVotingVoteTimeout = _.parseInt(setVotingVoteTimeout);
+  };
+
+  this.getResult = function() {
+    return config;
+  };
+}
+
+/**
+ * @public
+ */
+function loadConfig(filePath, done) {
+  var builder = new ConfigBuilder();
+  var stream = fs.createReadStream(filePath);
+  var reader = readline.createInterface(stream, {});
+  var lineno = 0;
+  var error = null;
+  var is_comment = function(line) { return !!(line.lastIndexOf('#', 0) === 0); };
+  var is_not_comment = function(line) { return !is_comment(line); };
+
+  stream.on('error', function onStreamError(err) {
+    done(err, null);
+  })
+
+  reader.on('line', function onReadLine(line) {
+    lineno += 1;
+
+    if (line === '' || is_comment(line)) {
+      return;
+    }
+
+    var xs = _.head(line.split(/\s+/), is_not_comment);
+    var key = _.first(xs);
+    var value = null;
+
+    switch (key) {
+    case 'DefaultTopic':
+      // Ad-hoc quoted string handling
+      value = [shlex_split(line)[1]];
+      break;
+    default:
+      value = _.rest(xs);
+      break;
+    }
+
+    var method = builder[key];
+    console.log(key)
+    if (_.isFunction(method) && value !== null) {
+      method.apply(builder, value);
+    } else {
+      error = format("Unknown key %s at line: %d", key, lineno);
+      stream.close();
+    }
+  });
+
+  stream.once('end', function() {
+    done(error, builder.getResult());
+  });
+}
+
+exports.ConfigBuilder = ConfigBuilder;
+exports.loadConfig = loadConfig;

--- a/test/config-parser_spec.js
+++ b/test/config-parser_spec.js
@@ -1,0 +1,58 @@
+
+var configParser = require('../src/config-parser');
+var ConfigBuilder = configParser.ConfigBuilder;
+var loadConfig = configParser.loadConfig;
+
+var fixtures = {
+  'example.cfg': './test/fixtures/example.cfg',
+  'invalid.cfg': './test/fixtures/invalid.cfg',
+};
+
+describe('config-parser.js', function() {
+  describe('ConfigBuilder', function() {
+    it('should return bare config dictionary', function() {
+      var builder = new ConfigBuilder();
+      var config = builder.getResult();
+
+      expect(config).to.have.property('ACL');
+      expect(config).to.have.property('User');
+       expect(config.ACL).to.be.empty;
+       expect(config.User).to.be.empty;
+      expect(_.keys(config)).to.have.length(2);
+    });
+  });
+
+  describe('loadConfig', function() {
+    it('load example.cfg', function(done) {
+      loadConfig(fixtures['example.cfg'], function loaded(err, config) {
+        expect(err).to.be.null;
+        expect(config).to.be.an('object');
+
+        expect(config).to.have.property('Port');
+        expect(config.Port).to.equal(2049);
+
+        done();
+      });
+    });
+
+    it('load file not found', function(done) {
+      loadConfig('this_path_does_not_exists.cfg', function loaded(err, config) {
+        expect(err).not.to.be.null;
+        expect(err).to.have.property('errno');
+        expect(err).to.have.property('code');
+        expect(err).to.have.property('path');
+        expect(err.errno).to.equal(34); // XXX: what this value?
+        expect(err.code).to.equal('ENOENT');
+        done();
+      });
+    });
+
+    it('load invalid.cfg', function(done) {
+      loadConfig(fixtures['invalid.cfg'], function loaded(err, config) {
+        expect(err).not.to.be.null;
+        expect(err).to.match(/^Unknown key (.*) at line: \d+/);
+        done();
+      });
+    });
+  });
+});

--- a/test/fixtures/example.cfg
+++ b/test/fixtures/example.cfg
@@ -1,0 +1,24 @@
+# Comment line
+Port 2048 # with comment
+Port 2049 #with a comment
+
+DefaultBPI 8
+DefaultBPM 120
+DefaultTopic "Sample topic"
+
+MaxUsers 8
+MaxChannels 32 2
+ServerLicense cclicense.txt
+
+AnonymousUsers yes
+AnonymousUsersCanChat yes
+AnonymousMaskIP yes
+AllowHiddenUsers no
+
+ACL 0.0.0.0/8 deny
+
+User foo bar *
+User foo bar
+
+SetVotingThreshold 50
+SetVotingVoteTimeout 60

--- a/test/fixtures/invalid.cfg
+++ b/test/fixtures/invalid.cfg
@@ -1,0 +1,5 @@
+
+AllowHiddenUsers x
+
+Porta 2--
+


### PR DESCRIPTION
This module will parse and build server config from the traditional ninjam server v0.06

As commented in the source, this does not handle legacy config file completely,
and it won't be fixed. The legacy code should be removed to reduce maintenance cost.
Use JSON config, it is easy, YAML/CSON format maybe more user friendly.

Why this module exists?
Because, as sample of custom config builder implementations.
It is not so important task on this domain, to be compatible with original.
